### PR TITLE
(hotfix) Fix post comments sorting by top rated

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,6 +26,6 @@ class Post < ApplicationRecord
   end
 
   def comments_sorted_by_user_score
-    sort_by_votes(collection: comments.includes(:author), direction: 'asc')
+    sort_by_votes(collection: comments.includes(:author), direction: 'desc')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   has_many :posts, inverse_of: :author, foreign_key: :author_id
   has_many :subs, inverse_of: :moderator, foreign_key: :moderator_id
   has_many :comments, foreign_key: :author_id, dependent: :destroy
+  has_many :votes, dependent: :destroy
 
   attr_reader :password
 


### PR DESCRIPTION
Post comments were sorted by worst first by accident. Fixed that :) 
Also added missing has_many votes for User